### PR TITLE
Add support documentation to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,44 @@
-# NestMindLS
+# Support
 
+Welcome to the NestMind Support page. If you have any issues or questions, this is the right place.
+
+---
+
+## Contact Us
+- 📧 **nestmind.help@gmail.com**  
+Typical response time: 24–48 hours (UK business days).
+
+---
+
+## Getting Started
+**Q: How do I add a bookmark or video?**  
+A: Paste a URL or use the iOS Share Sheet from Safari or YouTube.
+
+**Q: What are “Threads”?**  
+A: Threads group your todos, bookmarks, and videos into one journey.
+
+---
+
+## Sync (iCloud / CloudKit)
+**Q: What happens if I enable CloudKit after I already have local data?**  
+A: Existing items will sync to your iCloud. The first sync may take time; keep the app open.  
+
+**Q: I enabled sync but don’t see my items on another device.**  
+A: Make sure you’re signed into the same Apple ID, iCloud Drive is enabled, and NestMind has iCloud permission.
+
+---
+
+## Assistant
+**Q: Does the Assistant send my data to servers?**  
+A: No. It runs on-device. If a feature ever requires network access, you’ll be notified first.
+
+---
+
+## Known Issues
+- Initial iCloud sync may be slow for large libraries. Keep the app in the foreground until complete.  
+
+---
+
+## Need More Help?
+If you didn’t find your answer here, email us at:  
+📧 **nestmind.help@gmail.com**


### PR DESCRIPTION
## Summary
- replace the placeholder README with detailed support information for NestMind
- document contact details, getting started guidance, sync behavior, assistant privacy, and known issues for users

## Testing
- not run (documentation change)

------
https://chatgpt.com/codex/tasks/task_e_68dfd6fd18ec8321b454ecd171a96b86